### PR TITLE
Add adaptive target birth and initial pruning

### DIFF
--- a/lmb/lmb.py
+++ b/lmb/lmb.py
@@ -18,6 +18,12 @@ class LMB():
     ------
     params.log_p_survival : float
         Target survival probability as log-likelihood
+    params.p_birth : float
+        Maximum birth probability of targets
+    params.adaptive_birth_th : float
+        Birth probability threshold for existence probability of targets
+    params.log_r_prun_th : float
+        Log-likelihood threshold of target existence probability for pruning
 
     Attributes
     ----------
@@ -25,16 +31,20 @@ class LMB():
         List of currently active targets
     """
     def __init__(self, params=None):
+        self._ts = 0
         self.params = params if params else TrackerParameters()
         self.log_p_survival = np.log(self.params.p_survival)
+        self.p_birth = self.params.p_birth
+        self.adaptive_birth_th = self.params.adaptive_birth_th
+        self.log_r_prun_th = self.params.log_r_prun_th
         self.ranked_assign = self.params.ranked_assign
 
         self.targets = [] # list of currently tracked targets
-        self.targets.append(Target("0", pdf=GM(params=params)))
-        self.targets.append(Target("1", pdf=GM(params=params, x0=[20.,50.,0.,0.])))
-        self.targets.append(Target("2", pdf=GM(params=params, x0=[1.,-1.,0.,0.])))
-        self.targets.append(Target("3", pdf=GM(params=params, x0=[-10.,-10.,0.,0.])))
-        self.targets.append(Target("4", pdf=GM(params=params, x0=[10.,10.,0.,0.])))
+        self._spawn_target(log_r=0., x0=None)
+        self._spawn_target(log_r=0., x0=[20.,50.,0.,0.])
+        self._spawn_target(log_r=0., x0=[1.,-1.,0.,0.])
+        self._spawn_target(log_r=0., x0=[-10.,-10.,0.,0.])
+        self._spawn_target(log_r=0., x0=[10.,10.,0.,0.])
 
     def update(self,z):
         """
@@ -49,6 +59,9 @@ class LMB():
         out: array_like
             updated tracks
         """
+        self._ts += 1
+        print('Update step ', self._ts)
+
         self.predict()
         self.correct(z)
 
@@ -62,6 +75,9 @@ class LMB():
         """
         for target in self.targets:
             target.predict(self.log_p_survival)
+        
+        print('Predicted targets ', self.targets)
+
 
     def correct(self, z):
         """
@@ -90,22 +106,61 @@ class LMB():
         ## 2. Compute hypothesis weights using specified ranked assignment algorithm
         hyp_weights = np.zeros((N, M + 2))
         self.ranked_assign(C, hyp_weights)
-        hyp_weights = np.log(hyp_weights)
+        #hyp_weights = np.log(hyp_weights)
         ## 3. Calculate resulting existence probability of each target
         for i, target in enumerate(self.targets):
             target.correct(hyp_weights[i,:-1])
+
+        print('Corrected targets ', self.targets)
+        self._adaptive_birth(z, hyp_weights[:,:-2])
         ## 4. Prune targets
         self._prune()
+        print('Corrected, born, and pruned targets ', self.targets)
+
+
+    def _adaptive_birth(self, Z, assign_weights):
+        """
+        Adaptive birth of targets based on measurement
+
+        New targets are born at the measurement locations based on the 
+        assignment probabilities of these measurements: The higher the 
+        probability of a measurement being assign to any existing target,
+        the lower the birth probability of a new target at this position.
+
+        The implementation is based on the proposed algorithm in
+        S. Reuter et al., "The Labeled Multi-Bernoulli Filter", 2014
+
+        Parameters
+        ----------
+        Z : array_like
+            measurements
+        assign_weights : array_like
+            Weights of all track-measurement assignments (without missed detection or deaths)
+            Shape: num_tracks x num_measurements
+        """
+        # Probability of each measurement being assigned to an existing target
+        z_assign_prob = np.sum(assign_weights, axis=0)
+        not_assigned_sum = sum(1 - z_assign_prob)
+
+        if not_assigned_sum > 1e-9:
+            for z, prob in zip(Z, z_assign_prob):
+                # limit the birth existence probability to the configured p_birth
+                prob_birth = np.minimum(self.p_birth, (1 - prob)/not_assigned_sum)
+                # Spawn only new targets which exceed the existence prob threshold
+                if prob_birth > self.adaptive_birth_th:
+                    self._spawn_target(np.log(prob_birth), x0=[z['z'][0], z['z'][1], 0., 0.])
+
 
     def _prune(self):
         """
         Pruning of tracks
 
         Selection according to the configured pruning threshold for the existence probability.
-        Afterwards, limit the remaining tracks to the configured maximum number based on 
+        TODO: limit the remaining tracks to the configured maximum number based on 
         descending existence probability. 
         """
-        pass
+        self.targets = [t for t in self.targets if t.log_r > self.log_r_prun_th]
+
 
     def select(self):
         """
@@ -116,8 +171,16 @@ class LMB():
         """
         pass
 
-    def _spawn(self):
+    def _spawn_target(self, log_r, x0):
         """
         Spawn new target instances
+
+        Parameters
+        ----------
+        log_r : float
+            Log likelihood of initial existence probability
+        x0 : array_like
+            Initial state
         """
-        pass
+        label = '{}.{}'.format(self._ts, len(self.targets)) 
+        self.targets.append(Target(label, log_r=log_r, pdf=GM(params=self.params, x0=x0)))

--- a/lmb/parameters.py
+++ b/lmb/parameters.py
@@ -16,13 +16,15 @@ class TrackerParameters():
     n_targets_max: int = 1000   # maximum number of targets
     n_gm_cmpnts_max: int = 100  # maximum number of Gaussian mixture components
     p_survival: float = 0.99    # survival probability
-    p_birth: float = 0.02       # birth probability
+    p_birth: float = 0.2        # birth probability
+    adaptive_birth_th: float = 1e-3 # adaptive birth threshold
     p_detect: float = 0.99      # detection probability
     log_p_detect: float = field(init=False)
     log_q_detect: float = field(init=False)
     kappa: float = 0.01         # clutter intensity
     log_kappa: float = field(init=False)
-    r_prun_th: float = 1e-3     # existence probability pruning threshold
+    r_prun_th: float = 1e-2     # existence probability pruning threshold
+    log_r_prun_th: float = field(init=False)
     # observation noise covariance
     R: np.ndarray = np.asarray([[2., 0.],
                                 [0., 2.]], dtype=float_precision)
@@ -58,6 +60,7 @@ class TrackerParameters():
         object.__setattr__(self, 'log_p_detect', np.log(self.p_detect))
         object.__setattr__(self, 'log_q_detect', np.log(1 - self.p_detect))
         object.__setattr__(self, 'log_kappa', np.log(self.kappa))
+        object.__setattr__(self, 'log_r_prun_th', np.log(self.r_prun_th))
 
 @dataclass (frozen=True) 
 class SimParameters():

--- a/lmb/target.py
+++ b/lmb/target.py
@@ -27,7 +27,6 @@ class Target():
         self.pdf.predict()
         # Predict existence probability r
         self.log_r += log_p_survival
-        print('prediction: label ', self.label, 'log_r=',self.log_r, ' r=', np.exp(self.log_r))
 
     def correct(self, assignment_weights):
         """
@@ -42,10 +41,9 @@ class Target():
             Computed hypothesis weights (in log-likelihood) from ranked assignment
         """
         # 1.: self.log_r = sum of assignment weights
-        self.log_r = logsumexp(assignment_weights)
-        print('corrected label ', self.label, 'log_r=',self.log_r, ' r=', np.exp(self.log_r))
+        self.log_r = np.log(sum(assignment_weights))
         # 2.: Combine PDFs
-        self.pdf.overwrite_with_merged_pdf(self.assignments, assignment_weights - self.log_r)
+        self.pdf.overwrite_with_merged_pdf(self.assignments, np.log(assignment_weights) - self.log_r)
 
     def create_assignments(self, Z):
         """
@@ -82,5 +80,5 @@ class Target():
         """
         String representation of object
         """
-        return "T({} / {}: {})".format(self.label, self.log_r, self.pdf.mc)
+        return "\nTarget {}: r={})".format(self.label, np.exp(self.log_r))
 


### PR DESCRIPTION
This commit adds the adaptive birth function and
an initial target pruning based on the existence
probability threshold. Required additional parameters
are introduced and default birth parameters are
initially optimized.

Additionally, the calculation of log-likehood of
the hypothesis weights has been rearranged to reduce
the required number of computations in different
functions.

Furthermore, it refactors the printouts during
execution to improve the readability of current
targets.