### PR TITLE
Adaptive birth and tracker initialization refinement

### DIFF
--- a/lmb/lmb.py
+++ b/lmb/lmb.py
@@ -143,7 +143,7 @@ class LMB():
 
         New targets are born at the measurement locations based on the 
         assignment probabilities of these measurements: The higher the 
-        probability of a measurement being assign to any existing target,
+        probability of a measurement being assigned to any existing target,
         the lower the birth probability of a new target at this position.
 
         The implementation is based on the proposed algorithm in
@@ -163,8 +163,13 @@ class LMB():
 
         if not_assigned_sum > 1e-9:
             for z, prob in zip(Z, z_assign_prob):
+                # Set lambda_b to the mean cardinality of the birth multi-Bernoulli RFS
+                # This results in setting the birth prob to (1 - prob_assign).
+                self.lambda_b = not_assigned_sum
                 # limit the birth existence probability to the configured p_birth
-                prob_birth = np.minimum(self.p_birth, (1 - prob)/not_assigned_sum)
+                prob_birth = np.minimum(self.p_birth, self.lambda_b * (1 - prob)/not_assigned_sum)
+                ## Debug output:
+                # print("sum ", not_assigned_sum, " assign prob ", prob, " prob_birth ", prob_birth)
                 # Spawn only new targets which exceed the existence prob threshold
                 if prob_birth > self.adaptive_birth_th:
                     self._spawn_target(np.log(prob_birth), x0=[z['z'][0], z['z'][1], 0., 0.])

--- a/lmb/parameters.py
+++ b/lmb/parameters.py
@@ -14,13 +14,13 @@ class TrackerParameters():
     dim_x: int = 4              # Dimension (number) of states
     dim_z: int = 2              # Dimension (number) of measurement inputs
     n_targets_max: int = 1000   # maximum number of targets
-    n_gm_cmpnts_max: int = 100  # maximum number of Gaussian mixture components
-    log_w_prun_th: float = np.log(0.2)       # Log-likelihood threshold of gaussian mixture weight for pruning 
-    log_r_sel_th: float = np.log(0.2) # Log-likelihood threshold of target existence probability for selection
+    n_gm_cmpnts_max: int = 20  # maximum number of Gaussian mixture components
+    log_w_prun_th: float = np.log(0.1)       # Log-likelihood threshold of gaussian mixture weight for pruning 
+    log_r_sel_th: float = np.log(0.4) # Log-likelihood threshold of target existence probability for selection
     p_survival: float = 0.99    # survival probability
-    p_birth: float = 0.2        # birth probability
-    adaptive_birth_th: float = 1e-3 # adaptive birth threshold
-    p_detect: float = 0.99      # detection probability
+    p_birth: float = 0.6        # birth probability
+    adaptive_birth_th: float = 0.05 # adaptive birth threshold
+    p_detect: float = 0.9      # detection probability
     log_p_detect: float = field(init=False)
     log_q_detect: float = field(init=False)
     kappa: float = 0.01         # clutter intensity
@@ -69,7 +69,7 @@ class SimParameters():
     """
     Class containing the overall simulation parameters
     """                      
-    sim_length: int = 9  # number of simulation timesteps
+    sim_length: int = 14  # number of simulation timesteps
     dim_x: int = 4 # Dimension (number) of state variables
     dim_z: int = 2 # Dimension of measured state variables
     sigma: float = 0 # Standard deviation of measurement noise
@@ -97,7 +97,7 @@ class SimParameters():
                                           ('ts', 'u4')])
 
     # Array with state, birth and death information to generate tracks
-    init_track_info: np.ndarray = np.asarray([([10, 10, 2, 2],0, 7, 1.0),
+    init_track_info: np.ndarray = np.asarray([([10, 10, 2, 2],0, 12, 1.0),
                                               ([20, 50, 4, 5],0, 21, 2.0),
                                               ([35, 40, -3, -4],0, 21, 3.0),
                                               ([30, 90, 2, -4],0, 21, 4.0)],dtype=dt_init_track_info)


### PR DESCRIPTION
- Enables tracker initialization using adaptive birth, without previously spawned targets
- Add mean cardinality of new-born targets to adaptive birth to take estimated number of new-born targets in this update cycle into account for the calculation of birth probabilities

As a result, the performance on the 2D point example is improved significantly.
![Bildschirmfoto 2021-01-06 um 17 08 45](https://user-images.githubusercontent.com/24729371/103790742-e6c99900-5041-11eb-9b8f-64a7eb9f7810.png)
